### PR TITLE
Install torch before running setup.py

### DIFF
--- a/pytorch/setup.py
+++ b/pytorch/setup.py
@@ -1,8 +1,17 @@
 import io
 import os
 import re
-import torch
 from setuptools import setup, find_packages
+
+try:
+    import torch
+except ImportError:
+    import subprocess, sys
+
+    with open("requirements.txt") as f:
+        torch_version = [l.strip() for l in f if l.startswith("torch")][0]
+    subprocess.check_call([sys.executable, "-m", "pip", "install", torch_version])
+    import torch
 from torch.utils.cpp_extension import BuildExtension, CppExtension, CUDAExtension
 
 


### PR DESCRIPTION
nnutils needs torch available at setup time.

```bash
$ pip install nnutils-pytorch
Collecting nnutils-pytorch
    ERROR: Command errored out with exit status 1:
      File "/tmp/pip-install-ehymmer4/nnutils-pytorch/setup.py", line 4, in <module>
        import torch
    ModuleNotFoundError: No module named 'torch'
```
